### PR TITLE
Improve yt-dlp download server

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,35 +1,80 @@
 const express = require('express');
 const cors = require('cors');
+const { spawn } = require('child_process');
 const ytdl = require('ytdl-core');
-const ffmpeg = require('fluent-ffmpeg');
 
 const app = express();
 app.use(cors());
 
+function sanitizeFilename(name) {
+  return name.replace(/[\\/?%*:|"<>]/g, '');
+}
+
 app.get('/download/mp4', (req, res) => {
   const url = req.query.url;
-  if (!ytdl.validateURL(url)) return res.status(400).send('Invalid URL');
+  if (!ytdl.validateURL(url)) {
+    return res.status(400).json({ error: 'Invalid YouTube URL or failed to download.' });
+  }
 
-  res.header('Content-Disposition', 'attachment; filename="video.mp4"');
-  ytdl(url, { quality: 'highestvideo' }).pipe(res);
+  const titleProcess = spawn('yt-dlp', ['--get-title', url]);
+  let title = '';
+  titleProcess.stdout.on('data', data => title += data.toString());
+  titleProcess.stderr.on('data', data => console.error(data.toString()));
+
+  titleProcess.on('close', code => {
+    if (code !== 0) {
+      return res.status(400).json({ error: 'Invalid YouTube URL or failed to download.' });
+    }
+
+    title = sanitizeFilename(title.trim());
+    res.header('Content-Disposition', `attachment; filename="${title}.mp4"`);
+
+    const download = spawn('yt-dlp', ['-f', 'bestvideo[ext=mp4]+bestaudio[ext=m4a]/mp4', '-o', '-', url]);
+    download.stdout.pipe(res);
+    download.stderr.on('data', data => console.error(data.toString()));
+    download.on('close', dlCode => {
+      if (dlCode !== 0 && !res.headersSent) {
+        res.status(400).json({ error: 'Invalid YouTube URL or failed to download.' });
+      }
+    });
+  });
 });
 
 app.get('/download/mp3', (req, res) => {
   const url = req.query.url;
-  if (!ytdl.validateURL(url)) return res.status(400).send('Invalid URL');
+  if (!ytdl.validateURL(url)) {
+    return res.status(400).json({ error: 'Invalid YouTube URL or failed to download.' });
+  }
 
-  const stream = ytdl(url, { quality: 'highestaudio' });
+  const titleProcess = spawn('yt-dlp', ['--get-title', url]);
+  let title = '';
+  titleProcess.stdout.on('data', data => title += data.toString());
+  titleProcess.stderr.on('data', data => console.error(data.toString()));
 
-  res.header('Content-Disposition', 'attachment; filename="audio.mp3"');
+  titleProcess.on('close', code => {
+    if (code !== 0) {
+      return res.status(400).json({ error: 'Invalid YouTube URL or failed to download.' });
+    }
 
-  ffmpeg(stream)
-    .audioBitrate(128)
-    .toFormat('mp3')
-    .on('error', err => {
-      console.error('FFmpeg error:', err);
-      res.sendStatus(500);
-    })
-    .pipe(res, { end: true });
+    title = sanitizeFilename(title.trim());
+    res.header('Content-Disposition', `attachment; filename="${title}.mp3"`);
+
+    const download = spawn('yt-dlp', [
+      '--no-playlist',
+      '-f', 'bestaudio/best',
+      '--extract-audio',
+      '--audio-format', 'mp3',
+      '-o', '-',
+      url
+    ]);
+    download.stdout.pipe(res);
+    download.stderr.on('data', data => console.error(data.toString()));
+    download.on('close', dlCode => {
+      if (dlCode !== 0 && !res.headersSent) {
+        res.status(400).json({ error: 'Invalid YouTube URL or failed to download.' });
+      }
+    });
+  });
 });
 
 app.listen(3000, () => {


### PR DESCRIPTION
## Summary
- switch YouTube download logic to use `yt-dlp` CLI
- stream mp4/mp3 output using `child_process.spawn`
- set file names based on video title
- return JSON error when downloads fail

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6868110669188333b3fbe44b9921cad6